### PR TITLE
Simplify javadoc to enable RN 0.68 builds with newer gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -107,7 +107,8 @@ afterEvaluate { project ->
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
-        classpath += files(project.getConfigurations().getByName('compile').asList())
+//TODO revisit as it blocks build on RN 0.68
+//        classpath += files(project.getConfigurations().getByName('implementation').asList())
         include '**/*.java'
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-cognito-asf-fingerprint",
   "title": "React Native Cognito Asf Fingerprint",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "JS wrapper around native java and objc Cognito ASF libraries",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Related fixes  https://stackoverflow.com/questions/68724523/android-gradle-javadoc-broken-after-upgrade-to-gradle-7 if anyone is interested